### PR TITLE
Update UCI options for new iterative deepening

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -11,25 +11,27 @@
 #include "timeman.hpp"
 
 namespace Search {
-    Info Searcher::search() {
+    Info Searcher::startThinking() {
         Info result;
         Node root;
-        for(int i = 1; i <= 10; i++) {
-            root = this->alphaBeta(MIN_ALPHA, MAX_BETA, i, 0);
+
+        // perform iterative deepening
+        for(int i = 1; i <= this->depth_limit; i++) {
+            root = this->search(MIN_ALPHA, MAX_BETA, i, 0);
             
             if(this->tm.timeUp()) {
+                result.nodes = this->nodes;
                 result.timeElapsed = this->tm.getTimeElapsed();
                 break;
             }
             else {
-                result.nodes = this->nodes;
                 result.depth = this->max_depth;
-        
                 result.eval = root.eval;
                 result.move = root.move;
             }
         }
 
+        // compute mate-in
         if (root.eval > MAX_BETA - 100) {
             result.mateIn = MAX_BETA - root.eval;
         }
@@ -39,10 +41,8 @@ namespace Search {
         return result;
     }
 
-    Node Searcher::alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot) {
+    Node Searcher::search(int alpha, int beta, int depthLeft, int distanceFromRoot) {
         Node result;
-
-        
         if(this->tm.timeUp()) {
             return result;
         }
@@ -90,10 +90,10 @@ namespace Search {
         while (movePicker.movesLeft()) {
             BoardMove move = movePicker.pickMove();
             board.makeMove(move);
-            Node oppAlphaBeta = alphaBeta(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
+            Node opponent = search(-1 * beta, -1 * alpha, depthLeft - 1, distanceFromRoot + 1);
             board.undoMove(); 
             
-            score = -1 * oppAlphaBeta.eval;
+            score = -1 * opponent.eval;
             
             // prune if a move is too good; opponent side will avoid playing into this node
             if (score >= beta) {

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -32,19 +32,21 @@ namespace Search {
     
     class Searcher {
         public:  
-            Searcher(Board a_board, int ms) {
+            Searcher(Board a_board, int ms, int depthLimit) {
                 this->board = a_board;
                 this->nodes = 0;
                 this->max_depth = 0;
-                tm = Timeman::TimeManager(ms);
+                this->tm = Timeman::TimeManager(ms);
+                this->depth_limit = depthLimit;
             };
-            Info search();
-            Node alphaBeta(int alpha, int beta, int depthLeft, int distanceFromRoot);
+            Info startThinking();
+            Node search(int alpha, int beta, int depthLeft, int distanceFromRoot);
             int quiesce(int alpha, int beta, int depthLeft);
         private:
             Board board;
             uint64_t nodes;
             int max_depth;
             Timeman::TimeManager tm;
+            int depth_limit;
     };
 } // namespace Search

--- a/src/timeman.hpp
+++ b/src/timeman.hpp
@@ -19,7 +19,7 @@ namespace Timeman {
 
         TimeManager(int ms) {
             startTime = std::chrono::high_resolution_clock::now();
-            timeLimit = ms * 100;
+            timeLimit = ms * 1000 / 20;
         }
 
         bool timeUp() const;

--- a/src/uci.hpp
+++ b/src/uci.hpp
@@ -8,7 +8,7 @@
 
 namespace Uci {
     struct UciOptions {
-        int depth = 6;
+        int depth = 100;
     };
 
     bool uci();
@@ -24,6 +24,6 @@ namespace Uci {
     void isready();
 
     // for debugging
-    void perft(Board& board);
+    void perft(std::istringstream& input, Board& board);
 
 } // namespace Uci

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
     ../src/board.cpp
     ../src/moveGen.cpp
     ../src/movePicker.cpp
+    ../src/timeman.cpp
     ../src/search.cpp
     ../src/eval.cpp
 )


### PR DESCRIPTION
Iterative deepening + quiescence seems to mostly be done, so all there's left is to make updates to keep non-playing functionality the same. The main changes are:

- Max depth is still an option in UCI, though a set default is now depth 100. This maintains the benefits of iterative deepening while still allowing the flexibility for users to limit the depth for various purposes.
- The main search functions were renamed to ensure clarity. Some comments were added as well.
- Perft as a command no longer relies on OPTIONS.depth. Instead, an argument of depth is now required alongside perft.

There is one functional change in timeman.cpp where the default time allocated is 1/20th of the time left, which is a functional change that I've observed does better than 1/10th. This is still subject to change, and can be adjusted before merging iterative deepening into main.